### PR TITLE
Fixes ByteBuffer methods failing to apply arrayOffset() for array-backed buffers.

### DIFF
--- a/src/build/source_templates/compress.template
+++ b/src/build/source_templates/compress.template
@@ -119,7 +119,7 @@
   public int compress(${storage} src, final int srcOff, int srcLen, ${storage} dest, final int destOff, int maxDestLen) {
 @if{ storage == "ByteBuffer"}
     if (src.hasArray() && dest.hasArray()) {
-      return compress(src.array(), srcOff, srcLen, dest.array(), destOff, maxDestLen);
+      return compress(src.array(), srcOff + src.arrayOffset(), srcLen, dest.array(), destOff + dest.arrayOffset(), maxDestLen);
     }
     src = ${utils}.inNativeByteOrder(src);
     dest = ${utils}.inNativeByteOrder(dest);

--- a/src/build/source_templates/compress_hc.template
+++ b/src/build/source_templates/compress_hc.template
@@ -2,7 +2,7 @@
   public int compress(${storage} src, int srcOff, int srcLen, ${storage} dest, int destOff, int maxDestLen) {
 @if{ storage == "ByteBuffer"}
     if (src.hasArray() && dest.hasArray()) {
-      return compress(src.array(), srcOff, srcLen, dest.array(), destOff, maxDestLen);
+      return compress(src.array(), srcOff + src.arrayOffset(), srcLen, dest.array(), destOff + dest.arrayOffset(), maxDestLen);
     }
     src = ${utils}.inNativeByteOrder(src);
     dest = ${utils}.inNativeByteOrder(dest);

--- a/src/build/source_templates/decompress.template
+++ b/src/build/source_templates/decompress.template
@@ -2,7 +2,7 @@
   public int decompress(${storage} src, final int srcOff@if{ size == "Safe" }, final int srcLen @end{}, ${storage} dest, final int destOff, int destLen) {
 @if{ storage == "ByteBuffer"}
     if (src.hasArray() && dest.hasArray()) {
-      return decompress(src.array(), srcOff@if{ size == "Safe" }, srcLen@end{}, dest.array(), destOff, destLen);
+      return decompress(src.array(), srcOff + src.arrayOffset()@if{ size == "Safe" }, srcLen@end{}, dest.array(), destOff + dest.arrayOffset(), destLen);
     }
     src = ${utils}.inNativeByteOrder(src);
     dest = ${utils}.inNativeByteOrder(dest);

--- a/src/build/source_templates/xxhash32_hash.template
+++ b/src/build/source_templates/xxhash32_hash.template
@@ -2,7 +2,7 @@
   public int hash(${storage} buf, int off, int len, int seed) {
 @if{storage == "ByteBuffer"}
     if (buf.hasArray()) {
-      return hash(buf.array(), off, len, seed);
+      return hash(buf.array(), off + buf.arrayOffset(), len, seed);
     }
     ${utils}.checkRange(buf, off, len);
     buf = ${utils}.inLittleEndianOrder(buf);

--- a/src/build/source_templates/xxhash64_hash.template
+++ b/src/build/source_templates/xxhash64_hash.template
@@ -2,7 +2,7 @@
   public long hash(${storage} buf, int off, int len, long seed) {
 @if{storage == "ByteBuffer"}
     if (buf.hasArray()) {
-      return hash(buf.array(), off, len, seed);
+      return hash(buf.array(), off + buf.arrayOffset(), len, seed);
     }
     ${utils}.checkRange(buf, off, len);
     buf = ${utils}.inLittleEndianOrder(buf);

--- a/src/java/net/jpountz/lz4/LZ4HCJNICompressor.java
+++ b/src/java/net/jpountz/lz4/LZ4HCJNICompressor.java
@@ -54,20 +54,24 @@ final class LZ4HCJNICompressor extends LZ4Compressor {
     ByteBufferUtils.checkRange(src, srcOff, srcLen);
     ByteBufferUtils.checkRange(dest, destOff, maxDestLen);
 
-    byte[] srcArr = null, destArr = null;
-    ByteBuffer srcBuf = null, destBuf = null;
-    if (src.hasArray()) {
-      srcArr = src.array();
-    } else if (src.isDirect()) {
-      srcBuf = src;
-    }
-    if (dest.hasArray()) {
-      destArr = dest.array();
-    } else if (dest.isDirect()) {
-      destBuf = dest;
-    }
+    if ((src.hasArray() || src.isDirect()) && (dest.hasArray() || dest.isDirect())) {
+      byte[] srcArr = null, destArr = null;
+      ByteBuffer srcBuf = null, destBuf = null;
+      if (src.hasArray()) {
+        srcArr = src.array();
+        srcOff += src.arrayOffset();
+      } else {
+        assert src.isDirect();
+        srcBuf = src;
+      }
+      if (dest.hasArray()) {
+        destArr = dest.array();
+        destOff += dest.arrayOffset();
+      } else {
+        assert dest.isDirect();
+        destBuf = dest;
+      }
 
-    if ((srcArr != null || srcBuf != null) && (destArr != null || destBuf != null)) {
       final int result = LZ4JNI.LZ4_compressHC(srcArr, srcBuf, srcOff, srcLen, destArr, destBuf, destOff, maxDestLen, compressionLevel);
       if (result <= 0) {
         throw new LZ4Exception();

--- a/src/java/net/jpountz/lz4/LZ4JNICompressor.java
+++ b/src/java/net/jpountz/lz4/LZ4JNICompressor.java
@@ -46,20 +46,24 @@ final class LZ4JNICompressor extends LZ4Compressor {
     checkRange(src, srcOff, srcLen);
     checkRange(dest, destOff, maxDestLen);
 
-    byte[] srcArr = null, destArr = null;
-    ByteBuffer srcBuf = null, destBuf = null;
-    if (src.hasArray()) {
-      srcArr = src.array();
-    } else if (src.isDirect()) {
-      srcBuf = src;
-    }
-    if (dest.hasArray()) {
-      destArr = dest.array();
-    } else if (dest.isDirect()) {
-      destBuf = dest;
-    }
+    if ((src.hasArray() || src.isDirect()) && (dest.hasArray() || dest.isDirect())) {
+      byte[] srcArr = null, destArr = null;
+      ByteBuffer srcBuf = null, destBuf = null;
+      if (src.hasArray()) {
+        srcArr = src.array();
+        srcOff += src.arrayOffset();
+      } else {
+        assert src.isDirect();
+        srcBuf = src;
+      }
+      if (dest.hasArray()) {
+        destArr = dest.array();
+        destOff += dest.arrayOffset();
+      } else {
+        assert dest.isDirect();
+        destBuf = dest;
+      }
 
-    if ((srcArr != null || srcBuf != null) && (destArr != null || destBuf != null)) {
       final int result = LZ4JNI.LZ4_compress_limitedOutput(srcArr, srcBuf, srcOff, srcLen, destArr, destBuf, destOff, maxDestLen);
       if (result <= 0) {
         throw new LZ4Exception("maxDestLen is too small");

--- a/src/java/net/jpountz/lz4/LZ4JNIFastDecompressor.java
+++ b/src/java/net/jpountz/lz4/LZ4JNIFastDecompressor.java
@@ -47,20 +47,24 @@ final class LZ4JNIFastDecompressor extends LZ4FastDecompressor {
     ByteBufferUtils.checkRange(src, srcOff);
     ByteBufferUtils.checkRange(dest, destOff, destLen);
 
-    byte[] srcArr = null, destArr = null;
-    ByteBuffer srcBuf = null, destBuf = null;
-    if (src.hasArray()) {
-      srcArr = src.array();
-    } else if (src.isDirect()) {
-      srcBuf = src;
-    }
-    if (dest.hasArray()) {
-      destArr = dest.array();
-    } else if (dest.isDirect()) {
-      destBuf = dest;
-    }
+    if ((src.hasArray() || src.isDirect()) && (dest.hasArray() || dest.isDirect())) {
+      byte[] srcArr = null, destArr = null;
+      ByteBuffer srcBuf = null, destBuf = null;
+      if (src.hasArray()) {
+        srcArr = src.array();
+        srcOff += src.arrayOffset();
+      } else {
+        assert src.isDirect();
+        srcBuf = src;
+      }
+      if (dest.hasArray()) {
+        destArr = dest.array();
+        destOff += dest.arrayOffset();
+      } else {
+        assert dest.isDirect();
+        destBuf = dest;
+      }
 
-    if ((srcArr != null || srcBuf != null) && (destArr != null || destBuf != null)) {
       final int result = LZ4JNI.LZ4_decompress_fast(srcArr, srcBuf, srcOff, destArr, destBuf, destOff, destLen);
       if (result < 0) {
         throw new LZ4Exception("Error decoding offset " + (srcOff - result) + " of input buffer");

--- a/src/java/net/jpountz/lz4/LZ4JNISafeDecompressor.java
+++ b/src/java/net/jpountz/lz4/LZ4JNISafeDecompressor.java
@@ -46,20 +46,24 @@ final class LZ4JNISafeDecompressor extends LZ4SafeDecompressor {
     ByteBufferUtils.checkRange(src, srcOff, srcLen);
     ByteBufferUtils.checkRange(dest, destOff, maxDestLen);
 
-    byte[] srcArr = null, destArr = null;
-    ByteBuffer srcBuf = null, destBuf = null;
-    if (src.hasArray()) {
-      srcArr = src.array();
-    } else if (src.isDirect()) {
-      srcBuf = src;
-    }
-    if (dest.hasArray()) {
-      destArr = dest.array();
-    } else if (dest.isDirect()) {
-      destBuf = dest;
-    }
+    if ((src.hasArray() || src.isDirect()) && (dest.hasArray() || dest.isDirect())) {
+      byte[] srcArr = null, destArr = null;
+      ByteBuffer srcBuf = null, destBuf = null;
+      if (src.hasArray()) {
+        srcArr = src.array();
+        srcOff += src.arrayOffset();
+      } else {
+        assert src.isDirect();
+        srcBuf = src;
+      }
+      if (dest.hasArray()) {
+        destArr = dest.array();
+        destOff += dest.arrayOffset();
+      } else {
+        assert dest.isDirect();
+        destBuf = dest;
+      }
 
-    if ((srcArr != null || srcBuf != null) && (destArr != null || destBuf != null)) {
       final int result = LZ4JNI.LZ4_decompress_safe(srcArr, srcBuf, srcOff, srcLen, destArr, destBuf, destOff, maxDestLen);
       if (result < 0) {
         throw new LZ4Exception("Error decoding offset " + (srcOff - result) + " of input buffer");

--- a/src/java/net/jpountz/xxhash/XXHash32JNI.java
+++ b/src/java/net/jpountz/xxhash/XXHash32JNI.java
@@ -36,7 +36,7 @@ final class XXHash32JNI extends XXHash32 {
       checkRange(buf, off, len);
       return XXHashJNI.XXH32BB(buf, off, len, seed);
     } else if (buf.hasArray()) {
-      return hash(buf.array(), off, len, seed);
+      return hash(buf.array(), off + buf.arrayOffset(), len, seed);
     } else {
       XXHash32 safeInstance = SAFE_INSTANCE;
       if (safeInstance == null) {

--- a/src/java/net/jpountz/xxhash/XXHash64JNI.java
+++ b/src/java/net/jpountz/xxhash/XXHash64JNI.java
@@ -36,7 +36,7 @@ final class XXHash64JNI extends XXHash64 {
       checkRange(buf, off, len);
       return XXHashJNI.XXH64BB(buf, off, len, seed);
     } else if (buf.hasArray()) {
-      return hash(buf.array(), off, len, seed);
+      return hash(buf.array(), off + buf.arrayOffset(), len, seed);
     } else {
       XXHash64 safeInstance = SAFE_INSTANCE;
       if (safeInstance == null) {

--- a/src/test/net/jpountz/lz4/AbstractLZ4Test.java
+++ b/src/test/net/jpountz/lz4/AbstractLZ4Test.java
@@ -82,11 +82,14 @@ public abstract class AbstractLZ4Test extends RandomizedTest {
       @Override
       public ByteBuffer allocate(int length) {
         ByteBuffer bb;
+        int slice = randomInt(5);
         if (randomBoolean()) {
-          bb = ByteBuffer.allocate(length);
+          bb = ByteBuffer.allocate(length + slice);
         } else {
-          bb = ByteBuffer.allocateDirect(length);
+          bb = ByteBuffer.allocateDirect(length + slice);
         }
+        bb.position(slice);
+        bb = bb.slice();
         if (randomBoolean()) {
           bb.order(ByteOrder.LITTLE_ENDIAN);
         } else {


### PR DESCRIPTION
Addressing issue #64.